### PR TITLE
Revert "use Flask API URL for scraper"

### DIFF
--- a/configs.js.EXAMPLE
+++ b/configs.js.EXAMPLE
@@ -2,7 +2,7 @@ module.exports = {
   MODE: process.env.NODE_ENV,
   DYNO_CART_SENDER: 'communicart.test@gmail.com',
   COMMUNICART_DOT_SENDER: process.env.COMMUNICART_DOT_SENDER,
-  GSA_SCRAPE_URL: 'http://127.0.0.1:5000',
+  GSA_SCRAPE_URL: 'http://gsa-advantage-scraper/cgi-bin/gsa-adv-cart.py',
   GSA_PASSWORD: process.env.GSA_PASSWORD,
   GSA_USERNAME: process.env.GSA_USERNAME,
   SIM_MAP_USER_EMAIL: {

--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -25,11 +25,12 @@ function generalizeScraperTraits(cartItems) {
 exports.scrape = function(cartNumber, callback) {
   var params = querystring.stringify({
     u: configs.GSA_USERNAME,
-    p: configs.GSA_PASSWORD
+    p: configs.GSA_PASSWORD,
+    cart_id: cartNumber
   });
 
   var options = {
-    url: configs.GSA_SCRAPE_URL + '/api/v1/carts/' + cartNumber + '?' + params,
+    url: configs.GSA_SCRAPE_URL + '?' + params,
     json: true
   };
 

--- a/spec/ScraperSpec.js
+++ b/spec/ScraperSpec.js
@@ -7,7 +7,7 @@ var scraper = rewire('../lib/scraper');
 scraper.__set__('configs', {
   GSA_USERNAME: 'user',
   GSA_PASSWORD: 'password',
-  GSA_SCRAPE_URL: 'http://localhost:5000'
+  GSA_SCRAPE_URL: 'http://gsa-advantage-scraper/cgi-bin/gsa-adv-cart.py'
 });
 
 describe('scraper.scrape()', function() {
@@ -21,8 +21,8 @@ describe('scraper.scrape()', function() {
 
   it("transforms the data", function() {
     var json = fs.readFileSync('spec/data/cart.json');
-    nock('http://localhost:5000').
-      get('/api/v1/carts/123?u=user&p=password').
+    nock('http://gsa-advantage-scraper').
+      get('/cgi-bin/gsa-adv-cart.py?u=user&p=password&cart_id=123').
       reply(200, json);
 
     return scraper.scrape(123).then(function(data) {
@@ -45,9 +45,9 @@ describe('scraper.scrape()', function() {
   });
 
   it("handles errors gracefully", function() {
-    nock('http://localhost:5000').
-      get('/api/v1/carts/123?u=user&p=password').
-      reply(500);
+    nock('http://gsa-advantage-scraper').
+      get('/cgi-bin/gsa-adv-cart.py?u=user&p=password&cart_id=123').
+      reply(500, {});
 
     return scraper.scrape(123).catch(function(response) {
       expect(response.statusCode).to.eql(500);


### PR DESCRIPTION
This reverts commit 4b2425e77f9ec0b4d4017ce04e27ab3bd73518e8.

Conflicts:
    configs.js.EXAMPLE
    mailreader.js

Go back to calling the CGI script instead.
