### PR TITLE
Bypass validating ssl certificates

### DIFF
--- a/mailreader.js
+++ b/mailreader.js
@@ -61,6 +61,7 @@ function executeInitiationMailDelivery(path, analysis) {
     method: 'POST',
     json: analysis,
     path: "",
+    rejectUnauthorized: false,
     headers: {'X-Api-Key': configs.C2_API_KEY}
   };
 


### PR DESCRIPTION
Needed this to fix the following error when making requests from Mario to C2.

error:Error: DEPTH_ZERO_SELF_SIGNED_CERT

We want to allow self signed https certs between Mario and C2.
